### PR TITLE
Update kanban flow

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   assign-author:
     name: Auto-assign pull request author
-    if: github.repository_owner == 'consul'
+    if: github.repository_owner == 'rockandror'
     runs-on: ubuntu-latest
     steps:
       - uses: toshimaru/auto-author-assign@v1.4.0

--- a/.github/workflows/kanban.yml
+++ b/.github/workflows/kanban.yml
@@ -3,7 +3,7 @@ on:
   pull_request_target:
     types: [opened, reopened]
 env:
-  MY_GITHUB_TOKEN: ${{ secrets.KANBAN_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.KANBAN_TOKEN }}
 
 jobs:
   assign_one_project:


### PR DESCRIPTION
## References
Related PR: #4 

## Objectives
Configure correctly Kanban.yml and auto-author-assign.yml.
According to the [documentation](https://github.com/srggrs/assign-one-project-github-action/tree/1.3.1) the env variables are defined differently for Repository project than for Organisation or User project.