### PR TITLE
Revert "Replace quotes by single quotes on Kanban.yml"

### DIFF
--- a/.github/workflows/kanban.yml
+++ b/.github/workflows/kanban.yml
@@ -15,12 +15,12 @@ jobs:
       uses: srggrs/assign-one-project-github-action@1.3.1
       if: github.event.pull_request.draft == false
       with:
-        project: 'https://github.com/rockandror/rcn-consul/projects/3'
-        column_name: 'Reviewing'
+        project: "https://github.com/rockandror/rcn-consul/projects/3"
+        column_name: "Reviewing"
 
     - name: Assign new draft pull requests to the doing column
       uses: srggrs/assign-one-project-github-action@1.3.1
       if: github.event.pull_request.draft == true
       with:
-        project: 'https://github.com/rockandror/rcn-consul/projects/3'
-        column_name: 'Doing'
+        project: "https://github.com/rockandror/rcn-consul/projects/3"
+        column_name: "Doing"


### PR DESCRIPTION
Reverts rockandror/rcn-consul#6

Single quotes are the reason all projects have so many issues :stuck_out_tongue:.

We were using it while trying to find out why the kanban management integration wasn't working, but it isn't related to these quotes.