### PR TITLE
Use the latest Ubuntu image to run tests and coveralls

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,9 @@
 name: Docker
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     services:
       postgres:
@@ -65,7 +65,7 @@ jobs:
   coveralls:
     permissions:
       contents: none
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: tests
     env:
       CI_BUILD_NUMBER: ${{ github.run_number }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ on:
     branches-ignore:
       - i18n_master
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-18.04
@@ -60,6 +63,8 @@ jobs:
           name: screenshots
           path: tmp/screenshots
   coveralls:
+    permissions:
+      contents: none
     runs-on: ubuntu-18.04
     needs: tests
     env:


### PR DESCRIPTION
# References

* actions/runner-images/issues/6002

Port from CONSUL:

* consul/consul/pull/4855
* consul/consul/pull/4906

Tests and coveralls workflows stopped working since Github Action has deprecated the Ubuntu 18.04 image.

## Objectives

Run the latest Ubuntu image, so we do not have to update the workflow each time the system we use becomes deprecated.