### PR TITLE
Improve answers information section

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -156,3 +156,9 @@ body:not(.admin) {
     margin-bottom: 0;
   }
 }
+
+.poll-more-info-answers {
+  .column:nth-child(odd) {
+    border-right: 0;
+  }
+}

--- a/app/models/custom/poll/question/answer.rb
+++ b/app/models/custom/poll/question/answer.rb
@@ -7,4 +7,8 @@ class Poll::Question::Answer
   def total_votes
     answers.count + partial_results.sum(:amount)
   end
+
+  def has_more_information?
+    description.present? || documents.any? || images.any? || videos.any?
+  end
 end

--- a/app/views/custom/polls/show.html.erb
+++ b/app/views/custom/polls/show.html.erb
@@ -56,21 +56,8 @@
 
           <% if answer.description.present? %>
             <div class="margin-top">
-              <div id="answer_description_<%= answer.id %>" class="answer-description short" data-toggler="short">
+              <div id="answer_description_<%= answer.id %>" class="answer-description">
                 <%= wysiwyg(answer.description) %>
-              </div>
-              <div class="read-more">
-                <button type="button" id="read_more_<%= answer.id %>"
-                   data-toggle="answer_description_<%= answer.id %> read_more_<%= answer.id %> read_less_<%= answer.id %>"
-                   data-toggler="hide">
-                  <%= t("polls.show.read_more", answer: answer.title) %>
-                </button>
-                <button type="button" id="read_less_<%= answer.id %>"
-                   data-toggle="answer_description_<%= answer.id %> read_more_<%= answer.id %> read_less_<%= answer.id %>"
-                   data-toggler="hide"
-                   class="hide">
-                  <%= t("polls.show.read_less", answer: answer.title) %>
-                </button>
               </div>
             </div>
           <% end %>

--- a/app/views/custom/polls/show.html.erb
+++ b/app/views/custom/polls/show.html.erb
@@ -47,7 +47,7 @@
   <div id="poll_more_info_answers" class="expanded poll-more-info-answers">
     <div class="row padding">
       <% @poll_questions_answers.select(&:has_more_information?).each do |answer| %>
-        <div class="small-12 medium-6 column end answer <%= cycle("first", "") %>" id="answer_<%= answer.id %>">
+        <div class="small-12 column end answer" id="answer_<%= answer.id %>">
           <h3><%= answer.title %></h3>
 
           <% if answer.images.any? %>

--- a/app/views/custom/polls/show.html.erb
+++ b/app/views/custom/polls/show.html.erb
@@ -46,7 +46,7 @@
 
   <div id="poll_more_info_answers" class="expanded poll-more-info-answers">
     <div class="row padding">
-      <% @poll_questions_answers.each do |answer| %>
+      <% @poll_questions_answers.select(&:has_more_information?).each do |answer| %>
         <div class="small-12 medium-6 column end answer <%= cycle("first", "") %>" id="answer_<%= answer.id %>">
           <h3><%= answer.title %></h3>
 

--- a/spec/models/poll/question/answer_spec.rb
+++ b/spec/models/poll/question/answer_spec.rb
@@ -34,4 +34,30 @@ describe Poll::Question::Answer do
       expect(Poll::Question::Answer.with_content).to be_empty
     end
   end
+
+  describe "has_more_information?" do
+    it "returns false when it has no documents, no images, no videos, nor description" do
+      answer = create(:poll_question_answer, description: nil)
+
+      expect(answer.has_more_information?).to eq(false)
+    end
+
+    it "return true when it has documents, images, videos or description" do
+      answer = create(:poll_question_answer)
+
+      expect(answer.has_more_information?).to eq(true)
+
+      answer = create(:poll_question_answer, :with_image, description: nil)
+
+      expect(answer.has_more_information?).to eq(true)
+
+      answer = create(:poll_question_answer, :with_document, description: nil)
+
+      expect(answer.has_more_information?).to eq(true)
+
+      answer = create(:poll_question_answer, :with_document, description: nil)
+
+      expect(answer.has_more_information?).to eq(true)
+    end
+  end
 end

--- a/spec/system/polls/polls_spec.rb
+++ b/spec/system/polls/polls_spec.rb
@@ -215,6 +215,30 @@ describe "Polls" do
       end
     end
 
+    scenario "Do not show answers without more information at more information section" do
+      question = create(:poll_question, poll: poll)
+      answer_with_description = create(:poll_question_answer, title: "Description", question: question,
+        given_order: 1)
+      answer_with_image = create(:poll_question_answer, :with_image, title: "Image", question: question,
+        given_order: 2)
+      answer_with_document = create(:poll_question_answer, :with_document, title: "Document",
+        question: question, given_order: 3)
+      answer_with_video = create(:poll_question_answer, :with_video, title: "Video", question: question,
+        given_order: 4,)
+      answer_empty = create(:poll_question_answer, title: "Empty", question: question, given_order: 5,
+        description: nil, images: [], documents: [], videos: [])
+
+      visit poll_path(poll)
+
+      within("div.poll-more-info-answers") do
+        expect(page).to have_content(answer_with_description.title)
+        expect(page).to have_content(answer_with_image.title)
+        expect(page).to have_content(answer_with_document.title)
+        expect(page).to have_content(answer_with_video.title)
+        expect(page).not_to have_content(answer_empty.title)
+      end
+    end
+
     scenario "Answer images are shown" do
       question = create(:poll_question, :yes_no, poll: poll)
       create(:image, imageable: question.question_answers.first, title: "The yes movement")


### PR DESCRIPTION
## References
Depends on:
* #9 

Ported from:
* rockandror/innoviris-consul#8
* rockandror/innoviris-consul#24

## Objectives

* Show answers information with the following information: description, documents, images or videos.
* Use a full row for each poll question answer.
* Remove toggles

## Visual Changes

**Before**
<img width="1075" alt="Captura de Pantalla 2022-05-09 a las 16 16 12" src="https://user-images.githubusercontent.com/15726/167429851-4fdee561-1492-4ef6-b5fd-68e7ac462957.png">

**After**
<img width="1066" alt="Captura de Pantalla 2022-05-09 a las 16 15 50" src="https://user-images.githubusercontent.com/15726/167429854-0215a31d-e97f-4759-b891-f499f647497d.png">
