### PR TITLE
Link to descriptions

### DIFF
--- a/app/models/custom/poll.rb
+++ b/app/models/custom/poll.rb
@@ -1,0 +1,7 @@
+require_dependency Rails.root.join("app", "models", "poll").to_s
+
+class Poll < ApplicationRecord
+  translates :answers_descriptions_link_text, touch: true
+  translates :answers_descriptions_title, touch: true
+  globalize_accessors
+end

--- a/app/views/custom/admin/poll/polls/_form.html.erb
+++ b/app/views/custom/admin/poll/polls/_form.html.erb
@@ -1,0 +1,73 @@
+<%= render "shared/globalize_locales", resource: @poll %>
+
+<%= translatable_form_for [:admin, @poll] do |f| %>
+  <%= render "shared/errors", resource: @poll %>
+
+  <div class="row">
+    <div class="clear">
+      <div class="small-12 medium-6 column">
+        <%= f.date_field :starts_at %>
+      </div>
+
+      <div class="small-12 medium-6 column">
+        <%= f.date_field :ends_at %>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <%= f.translatable_fields do |translations_form| %>
+      <div class="small-12 medium-6 column">
+        <%= translations_form.text_field :name %>
+      </div>
+
+      <div class="small-12 column">
+        <%= translations_form.text_area :summary, rows: 4 %>
+      </div>
+
+      <div class="small-12 column">
+        <%= translations_form.text_area :description, rows: 8 %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="row">
+    <div class="images small-12 column">
+      <%= render "images/nested_image", f: f %>
+    </div>
+
+    <div class="clear">
+      <div class="small-6 medium-6 column">
+        <%= f.check_box :geozone_restricted, data: { checkbox_toggle: "#geozones" } %>
+      </div>
+    </div>
+  </div>
+
+  <div id="geozones" style="<%= @poll.geozone_restricted? ? "" : "display:none" %>">
+    <div class="row">
+      <%= f.collection_check_boxes(:geozone_ids, @geozones, :id, :name) do |b| %>
+        <div class="small-6 medium-3 column">
+          <%= b.label do %>
+            <%= b.check_box + b.text %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="small-12 column">
+      <%= render SDG::RelatedListSelectorComponent.new(f) %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="clear">
+      <div class="small-12 medium-4 large-2 column">
+        <%= f.submit t("admin.polls.#{admin_submit_action(@poll)}.submit_button"),
+                     class: "button success expanded margin-top" %>
+      </div>
+    </div>
+  </div>
+
+<% end %>

--- a/app/views/custom/admin/poll/polls/_form.html.erb
+++ b/app/views/custom/admin/poll/polls/_form.html.erb
@@ -26,7 +26,15 @@
       </div>
 
       <div class="small-12 column">
+        <%= translations_form.text_area :answers_descriptions_link_text, rows: 4 %>
+      </div>
+
+      <div class="small-12 column">
         <%= translations_form.text_area :description, rows: 8 %>
+      </div>
+
+      <div class="small-12 medium-6 column end">
+        <%= translations_form.text_field :answers_descriptions_title %>
       </div>
     <% end %>
   </div>

--- a/app/views/custom/polls/show.html.erb
+++ b/app/views/custom/polls/show.html.erb
@@ -31,6 +31,14 @@
         <% end %>
       <% end %>
 
+      <% if @poll.answers_descriptions_link_text.present? &&
+            @poll_questions_answers.select(&:has_more_information?).any? %>
+        <div class="callout secondary">
+          <%= @poll.answers_descriptions_link_text %><br>
+          <%= link_to t("polls.show.answers_descriptions_link_text"), "#answers_descriptions_title" %>
+        </div>
+      <% end %>
+
       <%= render Poll::Answers::FormComponent.new(@poll, @poll_answers) %>
     </div>
   </div>
@@ -38,64 +46,70 @@
   <div class="expanded poll-more-info">
     <div class="row margin">
       <div class="small-12 medium-9 column">
-        <h3><%= t("polls.show.more_info_title") %></h3>
+        <h2><%= t("polls.show.more_info_title") %></h2>
         <%= auto_link_already_sanitized_html simple_format(@poll.description) %>
       </div>
     </div>
   </div>
 
-  <div id="poll_more_info_answers" class="expanded poll-more-info-answers">
-    <div class="row padding">
-      <% @poll_questions_answers.select(&:has_more_information?).each do |answer| %>
-        <div class="small-12 column end answer" id="answer_<%= answer.id %>">
-          <h3><%= answer.title %></h3>
-
-          <% if answer.images.any? %>
-            <%= render "gallery", answer: answer %>
-          <% end %>
-
-          <% if answer.description.present? %>
-            <div class="margin-top">
-              <div id="answer_description_<%= answer.id %>" class="answer-description">
-                <%= wysiwyg(answer.description) %>
-              </div>
-            </div>
-          <% end %>
-
-          <% if answer.documents.present? %>
-            <div class="document-link">
-              <p>
-                <span class="icon-document"></span>&nbsp;
-                <strong><%= t("polls.show.documents") %></strong>
-              </p>
-
-              <% answer.documents.each do |document| %>
-                  <%= link_to document.title,
-                              document.attachment,
-                              target: "_blank",
-                              rel: "nofollow" %><br>
-              <% end %>
-            </div>
-          <% end %>
-
-          <% if answer.videos.present? %>
-            <div class="video-link">
-              <p>
-                <span class="icon-video"></span>&nbsp;
-                <strong><%= t("polls.show.videos") %></strong>
-              </p>
-
-              <% answer.videos.each do |video| %>
-                  <%= link_to video.title,
-                              video.url,
-                              target: "_blank",
-                              rel: "nofollow" %><br>
-              <% end %>
-            </div>
-          <% end %>
+  <% if @poll_questions_answers.select(&:has_more_information?).any? %>
+    <div id="poll_more_info_answers" class="expanded poll-more-info-answers">
+      <div class="row padding">
+        <div class="small-12 column end">
+          <h2 id="answers_descriptions_title"><%= @poll.answers_descriptions_title %></h2>
         </div>
-      <% end %>
-    </div>
+
+        <% @poll_questions_answers.select(&:has_more_information?).each do |answer| %>
+          <div class="small-12 column end answer" id="answer_<%= answer.id %>">
+            <h3><%= answer.title %></h3>
+
+            <% if answer.images.any? %>
+              <%= render "gallery", answer: answer %>
+            <% end %>
+
+            <% if answer.description.present? %>
+              <div class="margin-top">
+                <div id="answer_description_<%= answer.id %>" class="answer-description">
+                  <%= wysiwyg(answer.description) %>
+                </div>
+              </div>
+            <% end %>
+
+            <% if answer.documents.present? %>
+              <div class="document-link">
+                <p>
+                  <span class="icon-document"></span>&nbsp;
+                  <strong><%= t("polls.show.documents") %></strong>
+                </p>
+
+                <% answer.documents.each do |document| %>
+                    <%= link_to document.title,
+                                document.attachment,
+                                target: "_blank",
+                                rel: "nofollow" %><br>
+                <% end %>
+              </div>
+            <% end %>
+
+            <% if answer.videos.present? %>
+              <div class="video-link">
+                <p>
+                  <span class="icon-video"></span>&nbsp;
+                  <strong><%= t("polls.show.videos") %></strong>
+                </p>
+
+                <% answer.videos.each do |video| %>
+                    <%= link_to video.title,
+                                video.url,
+                                target: "_blank",
+                                rel: "nofollow" %><br>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 
   <div class="tabs-content" data-tabs-content="polls_tabs">

--- a/config/locales/custom/en/activerecord.yml
+++ b/config/locales/custom/en/activerecord.yml
@@ -5,3 +5,6 @@ en:
         mandatory_answer: "Mandatory answer"
       poll/question/translation:
         description: "Description"
+      poll/translation:
+        answers_descriptions_link_text: "Text next to the link to jump to the answers description section"
+        answers_descriptions_title: "Answers descriptions title"

--- a/config/locales/custom/en/general.yml
+++ b/config/locales/custom/en/general.yml
@@ -16,3 +16,5 @@ en:
         error:
           one: "1 error prevented your answers from being saved. Please check the marked field to know how to correct it:"
           other: "%{count} errors prevented your answers from being saved. Please check the marked fields to know how to correct them:"
+    show:
+      answers_descriptions_link_text: "Read more"

--- a/db/migrate/20220524132649_add_descriptions_fields_to_poll_translations.rb
+++ b/db/migrate/20220524132649_add_descriptions_fields_to_poll_translations.rb
@@ -1,0 +1,6 @@
+class AddDescriptionsFieldsToPollTranslations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :poll_translations, :answers_descriptions_link_text, :text
+    add_column :poll_translations, :answers_descriptions_title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1191,6 +1191,8 @@ ActiveRecord::Schema.define(version: 2022_08_22_155714) do
     t.text "summary"
     t.text "description"
     t.datetime "hidden_at"
+    t.text "answers_descriptions_link_text"
+    t.string "answers_descriptions_title"
     t.index ["hidden_at"], name: "index_poll_translations_on_hidden_at"
     t.index ["locale"], name: "index_poll_translations_on_locale"
     t.index ["poll_id"], name: "index_poll_translations_on_poll_id"

--- a/spec/system/custom/admin/poll/polls_spec.rb
+++ b/spec/system/custom/admin/poll/polls_spec.rb
@@ -1,6 +1,33 @@
 require "rails_helper"
 
 describe "Admin polls", :admin do
+  scenario "Create poll with descriptions fields" do
+    visit new_admin_poll_path
+
+    start_date = 1.week.from_now.to_date
+    end_date = 2.weeks.from_now.to_date
+
+    fill_in "Name", with: "Upcoming poll"
+    fill_in "poll_starts_at", with: start_date
+    fill_in "poll_ends_at", with: end_date
+    fill_in "Summary", with: "Upcoming poll's summary. This poll..."
+    fill_in "Text next to the link to jump to the answers description section",
+            with: "You can find the answer descriptions..."
+    fill_in "Description", with: "Upcomming poll's description. This poll..."
+    fill_in "Answers descriptions title", with: "Answers descriptions for poll"
+
+    click_button "Create poll"
+
+    expect(page).to have_content "Poll created successfully"
+
+    visit admin_polls_path
+
+    click_link "Edit"
+
+    expect(page).to have_content "You can find the answer descriptions..."
+    expect(page).to have_field "Answers descriptions title", with: "Answers descriptions for poll"
+  end
+
   context "Results" do
     context "Poll show" do
       scenario "Show partial results" do

--- a/spec/system/custom/polls/polls_spec.rb
+++ b/spec/system/custom/polls/polls_spec.rb
@@ -47,6 +47,19 @@ describe "Polls" do
         expect(page).not_to have_css("span.help-text")
       end
     end
+
+    scenario "Show answers descriptions fields when defined" do
+      poll = create(:poll, answers_descriptions_link_text: "You can find the answer descriptions...",
+                           answers_descriptions_title: "Answers descriptions for poll")
+      question = create(:poll_question, poll: poll)
+      create(:poll_question_answer, question: question, title: "Yes")
+
+      visit poll_path(poll)
+
+      expect(page).to have_content "You can find the answer descriptions..."
+      expect(page).to have_link "Read more"
+      expect(page).to have_content "Answers descriptions for poll"
+    end
   end
 
   context "Answer" do


### PR DESCRIPTION
## References

Ported from:
* rockandror/innoviris-consul#27

## Objectives
Allow for informative text to be added between the summary and the first question. This text is intended to inform that at the bottom of the page there is a breakdown of the answers with a description.

This text is always accompanied by a link with the following text: "Go to answers descriptions" which takes us to the answers descriptions section. This text "Go to answers descriptions" is not found in the database. If we want to change it, we can update the `general.yml` file with the desired text.  Or directly through the `site customization texts` section from the administration (`/admin/site_customization/information_texts?tab=polls`). The key that refers to this text is:
`polls.show.answers_descriptions_link_text`

It is also allowed to add a title (h2) just before all the answer descriptions when creating a poll.

## Visual Changes

- Allow update descriptions fields when create a new poll
![Admin poll section](https://user-images.githubusercontent.com/16189/170209620-f5e98972-2462-4465-bed5-058b219b4d4f.png)

- Public poll page render informative text for answers descriptions section 
![Public poll page render informative text for answers descriptions section](https://user-images.githubusercontent.com/16189/170209618-586819ef-986e-44f7-afd6-022c146b4157.png)

- Public poll page render title for answers descriptions section
![Public poll page render title for answers descriptions section](https://user-images.githubusercontent.com/16189/170209614-d0d124c5-ca6f-4082-b8f7-dd8a2d6528ab.png)


