### PR TITLE
Add format validations to answers

### DIFF
--- a/app/controllers/custom/admin/poll/questions_controller.rb
+++ b/app/controllers/custom/admin/poll/questions_controller.rb
@@ -4,7 +4,7 @@ class Admin::Poll::QuestionsController < Admin::Poll::BaseController
   private
 
     def question_params
-      attributes = [:poll_id, :question, :proposal_id, :mandatory_answer]
+      attributes = [:poll_id, :question, :proposal_id, :mandatory_answer, :validator]
       params.require(:poll_question).permit(*attributes, translation_params(Poll::Question))
     end
 end

--- a/app/helpers/polls_helper.rb
+++ b/app/helpers/polls_helper.rb
@@ -45,4 +45,10 @@ module PollsHelper
   def show_polls_description?
     @active_poll.present? && @current_filter == "current"
   end
+
+  def question_validators_options
+    Poll::Question::VALIDATORS.map do |validator|
+      [t("polls.questions.validators.#{validator}"), validator]
+    end
+  end
 end

--- a/app/models/custom/poll/answer.rb
+++ b/app/models/custom/poll/answer.rb
@@ -11,6 +11,13 @@ class Poll::Answer
   validates :answer_id, inclusion: { in: ->(a) { a.question.question_answers.ids }},
                         if: ->(a) { a.question&.single_choice? },
                         allow_nil: true
+  validates :open_answer, format: { with: /\d{4}\Z/,
+                                    message: I18n.t("polls.answers.form.postal_code_validator") },
+                          if: ->(a) { a.question&.postal_code_validator? },
+                          allow_blank: true
+  validates :open_answer, numericality: { only_integer: true, greater_than: 10, less_than: 120 },
+                          if: ->(a) { a.question&.age_validator? },
+                          allow_blank: true
   validates :open_answer, presence: true,
                           unless: ->(a) { a.question&.single_choice? },
                           if: ->(a) { a.question&.mandatory_answer? }

--- a/app/models/custom/poll/question.rb
+++ b/app/models/custom/poll/question.rb
@@ -1,10 +1,19 @@
 require_dependency Rails.root.join("app", "models", "poll", "question").to_s
 
 class Poll::Question < ApplicationRecord
+  VALIDATORS = %w[none age postal_code].freeze
   translates :description, touch: true
   globalize_accessors
 
   def single_choice?
     question_answers.any?
+  end
+
+  def postal_code_validator?
+    validator == "postal_code"
+  end
+
+  def age_validator?
+    validator == "age"
   end
 end

--- a/app/views/custom/admin/poll/questions/_form.html.erb
+++ b/app/views/custom/admin/poll/questions/_form.html.erb
@@ -36,6 +36,13 @@
 
   <div class="row">
     <div class="small-12 medium-6 large-4 column">
+      <%= f.select :validator,
+                    options_for_select(question_validators_options, @question.validator) %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="small-12 medium-6 large-4 column">
       <%= f.check_box :mandatory_answer %>
     </div>
   </div>

--- a/config/locales/custom/en/general.yml
+++ b/config/locales/custom/en/general.yml
@@ -16,5 +16,11 @@ en:
         error:
           one: "1 error prevented your answers from being saved. Please check the marked field to know how to correct it:"
           other: "%{count} errors prevented your answers from being saved. Please check the marked fields to know how to correct them:"
+        postal_code_validator: "The postal code format is invalid. Allowed postal codes must contain four digits."
+    questions:
+      validators:
+        age: Age
+        none: Do not apply any validation
+        postal_code: Postal code
     show:
       answers_descriptions_link_text: "Read more"

--- a/db/migrate/20220527095739_add_validator_to_poll_questions.rb
+++ b/db/migrate/20220527095739_add_validator_to_poll_questions.rb
@@ -1,0 +1,5 @@
+class AddValidatorToPollQuestions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :poll_questions, :validator, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1143,6 +1143,7 @@ ActiveRecord::Schema.define(version: 2022_08_22_155714) do
     t.datetime "updated_at"
     t.tsvector "tsv"
     t.string "video_url"
+    t.string "validator"
     t.boolean "mandatory_answer", default: false, null: false
     t.index ["author_id"], name: "index_poll_questions_on_author_id"
     t.index ["poll_id"], name: "index_poll_questions_on_poll_id"

--- a/spec/models/custom/poll/question_spec.rb
+++ b/spec/models/custom/poll/question_spec.rb
@@ -16,4 +16,32 @@ RSpec.describe Poll::Question, type: :model do
       expect(poll_question.single_choice?).to be_truthy
     end
   end
+
+  describe "#postal_code_validator?" do
+    it "returns false when question has no validator" do
+      poll_question = create(:poll_question, validator: "none")
+
+      expect(poll_question.postal_code_validator?).to be_falsy
+    end
+
+    it "returns true when question has postal_code validator" do
+      poll_question = create(:poll_question, validator: "postal_code")
+
+      expect(poll_question.postal_code_validator?).to be_truthy
+    end
+  end
+
+  describe "#age_validator?" do
+    it "returns false when question has no validator" do
+      poll_question = create(:poll_question, validator: "none")
+
+      expect(poll_question.age_validator?).to be_falsy
+    end
+
+    it "returns true when question has postal_code validator" do
+      poll_question = create(:poll_question, validator: "age")
+
+      expect(poll_question.age_validator?).to be_truthy
+    end
+  end
 end

--- a/spec/system/custom/admin/poll/questions_spec.rb
+++ b/spec/system/custom/admin/poll/questions_spec.rb
@@ -54,4 +54,23 @@ describe "Admin poll questions", :admin do
 
     expect(page).to have_content("Useful description for question")
   end
+
+  scenario "Create with validator" do
+    poll = create(:poll, name: "Movies")
+    title = "What is the postal code of your town?"
+
+    visit admin_poll_path(poll)
+    click_link "Create question"
+
+    fill_in "Question", with: title
+    select "Postal code", from: "Validator"
+
+    click_button "Save"
+
+    expect(page).to have_content(title)
+
+    click_link "Edit question"
+
+    expect(page).to have_field "Validator", with: "postal_code"
+  end
 end

--- a/spec/system/custom/polls/polls_spec.rb
+++ b/spec/system/custom/polls/polls_spec.rb
@@ -198,5 +198,34 @@ describe "Polls" do
       expect(page).to have_content "1 error prevented your answers from being saved. Please check the " \
                                    "marked field to know how to correct it:"
     end
+
+    describe "Show validator errors" do
+      scenario "for postal_code_validator" do
+        poll = create(:poll)
+        open_question = create(:poll_question, poll: poll, validator: "postal_code")
+
+        visit poll_path(poll)
+        fill_in open_question.title, with: "1234AAAA"
+        click_button "Vote"
+
+        within "#question_#{open_question.id}_answer_fields" do
+          expect(page).to have_content("The postal code format is invalid. Allowed postal codes must " \
+                                       "contain four digits.")
+        end
+      end
+
+      scenario "for age_validator" do
+        poll = create(:poll)
+        open_question = create(:poll_question, poll: poll, validator: "age")
+
+        visit poll_path(poll)
+        fill_in open_question.title, with: "9"
+        click_button "Vote"
+
+        within "#question_#{open_question.id}_answer_fields" do
+          expect(page).to have_content("must be greater than 10")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## References

Depends on: 
* #15 

Ported from:
* rockandror/innoviris-consul#30


## Objectives
Allow add custom validation (as postal code and age) when create a new poll question.
This validation allow validate the format for postal_code (force 4 numbers) and for age (force 1 or 2 numbers)

## Visual Changes
- Admin poll question create
![Allow define custom validations when create a poll question](https://user-images.githubusercontent.com/16189/170708539-3f212884-c6c5-40cf-9ee4-bbc60787429a.png)

- Display validation error on answer when the format is invalid
![Display validation error on answer when the format is invalid](https://user-images.githubusercontent.com/16189/170708783-294a9d24-3af7-42e3-aebc-d71d60a54211.png)

